### PR TITLE
F/va 108 orphaned field collections

### DIFF
--- a/public_html/profiles/valhalla/modules/valghalla/modules/valghalla_internal_server/valghalla_internal_server.module
+++ b/public_html/profiles/valhalla/modules/valghalla/modules/valghalla_internal_server/valghalla_internal_server.module
@@ -145,6 +145,12 @@ function valghalla_internal_server_perform_synch($force = TRUE) {
     return;
   }
 
+  // Locking synch.
+  if (!lock_acquire('valghalla_internal_server_synch')) {
+    watchdog('valghalla_internal_server', 'Cannot start synch process, synch is already in progress. ', array(), WATCHDOG_WARNING);
+    return;
+  }
+
   // Update heartbeat.
   $ws = new ExternalWebservice();
   variable_set('valgalla_internal_server_heartbeat', $ws->heartbeat());
@@ -177,6 +183,9 @@ function valghalla_internal_server_perform_synch($force = TRUE) {
       }
     }
   }
+
+  // Unlocking synch.
+  lock_release('valghalla_internal_server_synch');
 }
 
 /**

--- a/public_html/profiles/valhalla/modules/valghalla/modules/valghalla_synch_node_export/includes/valghalla_synch_node_export.batch.inc
+++ b/public_html/profiles/valhalla/modules/valghalla/modules/valghalla_synch_node_export/includes/valghalla_synch_node_export.batch.inc
@@ -16,7 +16,7 @@
  */
 function valghalla_synch_node_export_batch_delete_orphaned_fcs($fc_items) {
   if (count($fc_items)) {
-    drupal_set_message(t('Preparing to delete @num field collection items(s).', array('@num' => count($fc_items))));
+    drupal_set_message(t('Deleting @num field collection items(s).', array('@num' => count($fc_items))));
   }
   else {
     drupal_set_message(t('No orphaned field collection items were found.'));
@@ -58,12 +58,13 @@ function valghalla_synch_node_export_batch_delete_orphaned_fcs($fc_items) {
  */
 function valghalla_synch_node_export_batch_delete_orphaned_fc_op($fc_item, $operation_details, &$context) {
   // Report progress.
-  $context['message'] = t('Deleting field_collection item @fc_item_id', array('@fc_item_id' => $fc_item->item_id));
+  $context['message'] = t('Deleting field_collection item @fc_item_id', array('@fc_item_id' => $fc_item));
 
-  $fc_item->delete();
+  $fc_loaded = entity_load_single('field_collection_item', $fc_item);
+  $fc_loaded->delete();
 
   $context['results'][] = array(
-    'message' => t('Deleted field_collection item "@fc_item_id"', array('@fc_item_id' => $fc_item->item_id)),
+    'message' => t('Deleted field_collection item "@fc_item_id"', array('@fc_item_id' => $fc_item)),
     'type' => 'status',
   );
 

--- a/public_html/profiles/valhalla/modules/valghalla/modules/valghalla_synch_node_export/includes/valghalla_synch_node_export.utils.inc
+++ b/public_html/profiles/valhalla/modules/valghalla/modules/valghalla_synch_node_export/includes/valghalla_synch_node_export.utils.inc
@@ -14,49 +14,12 @@
 function valgahalla_synch_node_export_find_orphaned_fc_items() {
   $orphaned_fcs = array();
 
-  // Getting all elections.
-  $query = new EntityFieldQuery();
-  $query->entityCondition('entity_type', 'node')
-    ->entityCondition('bundle', 'election');
-  $result = $query->execute();
-  if (isset($result['node'])) {
-    $all_election_ids = array_keys($result['node']);
-  }
-
-  // Getting all polling stations.
-  $query = new EntityFieldQuery();
-  $query->entityCondition('entity_type', 'node')
-    ->entityCondition('bundle', 'polling_station');
-  $result = $query->execute();
-  if (isset($result['node'])) {
-    $all_polling_stations_ids = array_keys($result['node']);
-  }
-
-  // Getting all roles.
-  $query = new EntityFieldQuery();
-  $query->entityCondition('entity_type', 'node')
-    ->entityCondition('bundle', 'roles');
-  $result = $query->execute();
-  if (isset($result['node'])) {
-    $all_roles_ids = array_keys($result['node']);
-  }
-
-  // Getting parties.
-  $party_vocab = taxonomy_vocabulary_machine_name_load('partier');
-  $query = new EntityFieldQuery();
-  $query->entityCondition('entity_type', 'taxonomy_term')
-    ->propertyCondition('vid', $party_vocab->vid);
-  $result = $query->execute();
-  if (isset($result['taxonomy_term'])) {
-    $all_parties_ids = array_keys($result['taxonomy_term']);
-  }
-
   // Field_electioninfo.
   // Finding field_electioninfo with non-valid host entity.
   $efq = new EntityFieldQuery();
   $efq->entityCondition('entity_type', 'field_collection_item');
   $efq->propertyCondition('field_name', 'field_electioninfo');
-  $efq->addTag('veine');
+  $efq->addTag('ei_host_null');
   $result = $efq->execute();
 
   if (is_array($result['field_collection_item'])) {
@@ -70,7 +33,8 @@ function valgahalla_synch_node_export_find_orphaned_fc_items() {
   $efq = new EntityFieldQuery();
   $efq->entityCondition('entity_type', 'field_collection_item');
   $efq->propertyCondition('field_name', 'field_electioninfo');
-  $efq->fieldCondition('field_election', 'target_id', $all_election_ids, 'NOT IN');
+  $efq->propertyCondition('archived', 0);
+  $efq->addTag('ei_field_election_empty');
   $result = $efq->execute();
 
   if (is_array($result['field_collection_item'])) {
@@ -84,7 +48,8 @@ function valgahalla_synch_node_export_find_orphaned_fc_items() {
   $efq = new EntityFieldQuery();
   $efq->entityCondition('entity_type', 'field_collection_item');
   $efq->propertyCondition('field_name', 'field_electioninfo');
-  $efq->fieldCondition('field_post_role', 'target_id', $all_roles_ids, 'NOT IN');
+  $efq->propertyCondition('archived', 0);
+  $efq->addTag('ei_field_post_role_empty');
   $result = $efq->execute();
 
   if (is_array($result['field_collection_item'])) {
@@ -98,7 +63,8 @@ function valgahalla_synch_node_export_find_orphaned_fc_items() {
   $efq = new EntityFieldQuery();
   $efq->entityCondition('entity_type', 'field_collection_item');
   $efq->propertyCondition('field_name', 'field_electioninfo');
-  $efq->fieldCondition('field_vlnt_station', 'target_id', $all_polling_stations_ids, 'NOT IN');
+  $efq->propertyCondition('archived', 0);
+  $efq->addTag('ei_field_vlnt_station_empty');
   $result = $efq->execute();
 
   if (is_array($result['field_collection_item'])) {
@@ -112,7 +78,8 @@ function valgahalla_synch_node_export_find_orphaned_fc_items() {
   $efq = new EntityFieldQuery();
   $efq->entityCondition('entity_type', 'field_collection_item');
   $efq->propertyCondition('field_name', 'field_electioninfo');
-  $efq->fieldCondition('field_post_party', 'target_id', $all_parties_ids, 'NOT IN');
+  $efq->propertyCondition('archived', 0);
+  $efq->addTag('ei_field_post_party_empty');
   $result = $efq->execute();
 
   if (is_array($result['field_collection_item'])) {
@@ -126,7 +93,7 @@ function valgahalla_synch_node_export_find_orphaned_fc_items() {
   $efq = new EntityFieldQuery();
   $efq->entityCondition('entity_type', 'field_collection_item');
   $efq->propertyCondition('field_name', 'field_volunteers_pr_pol_st_party');
-  $efq->addTag('vvppspne');
+  $efq->addTag('vppsp_host_null');
   $result = $efq->execute();
 
   if (is_array($result['field_collection_item'])) {
@@ -136,11 +103,12 @@ function valgahalla_synch_node_export_find_orphaned_fc_items() {
   }
 
   // Field_volunteers_pr_pol_st_party.
-  // Finding field_volunteers_pr_pol_st_party with non-valid field_ppsp_polling_station.
+  // Finding field_volunteers_pr_pol_st_party with non-valid
+  // field_ppsp_polling_station.
   $efq = new EntityFieldQuery();
   $efq->entityCondition('entity_type', 'field_collection_item');
   $efq->propertyCondition('field_name', 'field_volunteers_pr_pol_st_party');
-  $efq->fieldCondition('field_ppsp_polling_station', 'nid', $all_polling_stations_ids, 'NOT IN');
+  $efq->addTag('vppsp_field_ppsp_polling_station_empty');
   $result = $efq->execute();
 
   if (is_array($result['field_collection_item'])) {
@@ -154,7 +122,7 @@ function valgahalla_synch_node_export_find_orphaned_fc_items() {
   $efq = new EntityFieldQuery();
   $efq->entityCondition('entity_type', 'field_collection_item');
   $efq->propertyCondition('field_name', 'field_volunteers_pr_pol_st_party');
-  $efq->fieldCondition('field_ppsp_party', 'tid', $all_parties_ids, 'NOT IN');
+  $efq->addTag('vppsp_field_ppsp_party_empty');
   $result = $efq->execute();
 
   if (is_array($result['field_collection_item'])) {

--- a/public_html/profiles/valhalla/modules/valghalla/modules/valghalla_synch_node_export/includes/valghalla_synch_node_export.utils.inc
+++ b/public_html/profiles/valhalla/modules/valghalla/modules/valghalla_synch_node_export/includes/valghalla_synch_node_export.utils.inc
@@ -14,97 +14,158 @@
 function valgahalla_synch_node_export_find_orphaned_fc_items() {
   $orphaned_fcs = array();
 
-  // Looping through field_electioninfo fields collection.
+  // Getting all elections.
+  $query = new EntityFieldQuery();
+  $query->entityCondition('entity_type', 'node')
+    ->entityCondition('bundle', 'election');
+  $result = $query->execute();
+  if (isset($result['node'])) {
+    $all_election_ids = array_keys($result['node']);
+  }
+
+  // Getting all polling stations.
+  $query = new EntityFieldQuery();
+  $query->entityCondition('entity_type', 'node')
+    ->entityCondition('bundle', 'polling_station');
+  $result = $query->execute();
+  if (isset($result['node'])) {
+    $all_polling_stations_ids = array_keys($result['node']);
+  }
+
+  // Getting all roles.
+  $query = new EntityFieldQuery();
+  $query->entityCondition('entity_type', 'node')
+    ->entityCondition('bundle', 'roles');
+  $result = $query->execute();
+  if (isset($result['node'])) {
+    $all_roles_ids = array_keys($result['node']);
+  }
+
+  // Getting parties.
+  $party_vocab = taxonomy_vocabulary_machine_name_load('partier');
+  $query = new EntityFieldQuery();
+  $query->entityCondition('entity_type', 'taxonomy_term')
+    ->propertyCondition('vid', $party_vocab->vid);
+  $result = $query->execute();
+  if (isset($result['taxonomy_term'])) {
+    $all_parties_ids = array_keys($result['taxonomy_term']);
+  }
+
+  // Field_electioninfo.
+  // Finding field_electioninfo with non-valid host entity.
   $efq = new EntityFieldQuery();
   $efq->entityCondition('entity_type', 'field_collection_item');
   $efq->propertyCondition('field_name', 'field_electioninfo');
+  $efq->addTag('veine');
   $result = $efq->execute();
 
-  foreach ($result['field_collection_item'] as $fc) {
-    $fc_loaded = entity_load_single('field_collection_item', $fc->item_id);
-
-    // No valid host entity.
-    if (!$fc_loaded->hostEntity()) {
-      $orphaned_fcs[] = $fc_loaded;
-      continue;
-    }
-
-    // Checking field_election relation.
-    $field_election = field_get_items('field_collection_item', $fc_loaded, 'field_election');
-    if ($field_election && is_array($field_election)) {
-      $election_nid = $field_election[0]['target_id'];
-      if (!node_load($election_nid)) {
-        $orphaned_fcs[] = $fc_loaded;
-        continue;
-      }
-    }
-
-    // Checking field_post_role relation.
-    $field_post_role = field_get_items('field_collection_item', $fc_loaded, 'field_post_role');
-    if ($field_post_role && is_array($field_post_role)) {
-      $role_nid = $field_post_role[0]['target_id'];
-      if (!node_load($role_nid)) {
-        $orphaned_fcs[] = $fc_loaded;
-        continue;
-      }
-    }
-
-    // Checking field_vlnt_station relation.
-    $field_vlnt_station = field_get_items('field_collection_item', $fc_loaded, 'field_vlnt_station');
-    if ($field_vlnt_station && is_array($field_vlnt_station)) {
-      $polling_station_nid = $field_vlnt_station[0]['target_id'];
-      if (!node_load($polling_station_nid)) {
-        $orphaned_fcs[] = $fc_loaded;
-        continue;
-      }
-    }
-
-    // Checking field_post_party relation.
-    $field_post_party = field_get_items('field_collection_item', $fc_loaded, 'field_post_party');
-    if ($field_post_party && is_array($field_post_party)) {
-      $party_tid = $field_post_party[0]['target_id'];
-      if (!taxonomy_term_load($party_tid)) {
-        $orphaned_fcs[] = $fc_loaded;
-        continue;
-      }
+  if (is_array($result['field_collection_item'])) {
+    foreach ($result['field_collection_item'] as $fc) {
+      $orphaned_fcs[] = $fc->item_id;
     }
   }
 
-  // Looping through field_volunteers_pr_pol_st_party fields collection.
+  // Field_electioninfo.
+  // Finding field_electioninfo with non-valid field_election.
+  $efq = new EntityFieldQuery();
+  $efq->entityCondition('entity_type', 'field_collection_item');
+  $efq->propertyCondition('field_name', 'field_electioninfo');
+  $efq->fieldCondition('field_election', 'target_id', $all_election_ids, 'NOT IN');
+  $result = $efq->execute();
+
+  if (is_array($result['field_collection_item'])) {
+    foreach ($result['field_collection_item'] as $fc) {
+      $orphaned_fcs[] = $fc->item_id;
+    }
+  }
+
+  // Field_electioninfo.
+  // Finding field_electioninfo with non-valid field_post_role.
+  $efq = new EntityFieldQuery();
+  $efq->entityCondition('entity_type', 'field_collection_item');
+  $efq->propertyCondition('field_name', 'field_electioninfo');
+  $efq->fieldCondition('field_post_role', 'target_id', $all_roles_ids, 'NOT IN');
+  $result = $efq->execute();
+
+  if (is_array($result['field_collection_item'])) {
+    foreach ($result['field_collection_item'] as $fc) {
+      $orphaned_fcs[] = $fc->item_id;
+    }
+  }
+
+  // Field_electioninfo.
+  // Finding field_electioninfo with non-valid field_vlnt_station.
+  $efq = new EntityFieldQuery();
+  $efq->entityCondition('entity_type', 'field_collection_item');
+  $efq->propertyCondition('field_name', 'field_electioninfo');
+  $efq->fieldCondition('field_vlnt_station', 'target_id', $all_polling_stations_ids, 'NOT IN');
+  $result = $efq->execute();
+
+  if (is_array($result['field_collection_item'])) {
+    foreach ($result['field_collection_item'] as $fc) {
+      $orphaned_fcs[] = $fc->item_id;
+    }
+  }
+
+  // Field_electioninfo.
+  // Finding field_electioninfo with non-valid field_post_party.
+  $efq = new EntityFieldQuery();
+  $efq->entityCondition('entity_type', 'field_collection_item');
+  $efq->propertyCondition('field_name', 'field_electioninfo');
+  $efq->fieldCondition('field_post_party', 'target_id', $all_parties_ids, 'NOT IN');
+  $result = $efq->execute();
+
+  if (is_array($result['field_collection_item'])) {
+    foreach ($result['field_collection_item'] as $fc) {
+      $orphaned_fcs[] = $fc->item_id;
+    }
+  }
+
+  // Field_volunteers_pr_pol_st_party.
+  // Finding field_volunteers_pr_pol_st_party with non-valid host entity.
   $efq = new EntityFieldQuery();
   $efq->entityCondition('entity_type', 'field_collection_item');
   $efq->propertyCondition('field_name', 'field_volunteers_pr_pol_st_party');
+  $efq->addTag('vvppspne');
   $result = $efq->execute();
 
-  foreach ($result['field_collection_item'] as $fc) {
-    $fc_loaded = entity_load_single('field_collection_item', $fc->item_id);
-
-    // No valid host entity.
-    if (!$fc_loaded->hostEntity()) {
-      $orphaned_fcs[] = $fc_loaded;
-      continue;
-    }
-
-    // Checking field_volunteers_pr_pol_st_party relation.
-    $field_ppsp_polling_station = field_get_items('field_collection_item', $fc_loaded, 'field_ppsp_polling_station');
-    if ($field_ppsp_polling_station && is_array($field_ppsp_polling_station)) {
-      $polling_station_nid = $field_ppsp_polling_station[0]['nid'];
-      if (!node_load($polling_station_nid)) {
-        $orphaned_fcs[] = $fc_loaded;
-        continue;
-      }
-    }
-
-    // Checking field_ppsp_party relation.
-    $field_ppsp_party = field_get_items('field_collection_item', $fc_loaded, 'field_ppsp_party');
-    if ($field_ppsp_party && is_array($field_ppsp_party)) {
-      $party_tid = $field_ppsp_party[0]['tid'];
-      if (!taxonomy_term_load($party_tid)) {
-        $orphaned_fcs[] = $fc_loaded;
-        continue;
-      }
+  if (is_array($result['field_collection_item'])) {
+    foreach ($result['field_collection_item'] as $fc) {
+      $orphaned_fcs[] = $fc->item_id;
     }
   }
+
+  // Field_volunteers_pr_pol_st_party.
+  // Finding field_volunteers_pr_pol_st_party with non-valid field_ppsp_polling_station.
+  $efq = new EntityFieldQuery();
+  $efq->entityCondition('entity_type', 'field_collection_item');
+  $efq->propertyCondition('field_name', 'field_volunteers_pr_pol_st_party');
+  $efq->fieldCondition('field_ppsp_polling_station', 'nid', $all_polling_stations_ids, 'NOT IN');
+  $result = $efq->execute();
+
+  if (is_array($result['field_collection_item'])) {
+    foreach ($result['field_collection_item'] as $fc) {
+      $orphaned_fcs[] = $fc->item_id;
+    }
+  }
+
+  // Field_volunteers_pr_pol_st_party.
+  // Finding field_volunteers_pr_pol_st_party with non-valid field_ppsp_party.
+  $efq = new EntityFieldQuery();
+  $efq->entityCondition('entity_type', 'field_collection_item');
+  $efq->propertyCondition('field_name', 'field_volunteers_pr_pol_st_party');
+  $efq->fieldCondition('field_ppsp_party', 'tid', $all_parties_ids, 'NOT IN');
+  $result = $efq->execute();
+
+  if (is_array($result['field_collection_item'])) {
+    foreach ($result['field_collection_item'] as $fc) {
+      $orphaned_fcs[] = $fc->item_id;
+    }
+  }
+
+  $orphaned_fcs = array_unique($orphaned_fcs);
+  reset($orphaned_fcs);
+  sort($orphaned_fcs);
 
   return $orphaned_fcs;
 }

--- a/public_html/profiles/valhalla/modules/valghalla/modules/valghalla_synch_node_export/includes/valghalla_synch_node_export.utils.inc
+++ b/public_html/profiles/valhalla/modules/valghalla/modules/valghalla_synch_node_export/includes/valghalla_synch_node_export.utils.inc
@@ -19,6 +19,7 @@ function valgahalla_synch_node_export_find_orphaned_fc_items() {
   $efq = new EntityFieldQuery();
   $efq->entityCondition('entity_type', 'field_collection_item');
   $efq->propertyCondition('field_name', 'field_electioninfo');
+  $efq->propertyCondition('archived', 0);
   $efq->addTag('ei_host_null');
   $result = $efq->execute();
 
@@ -93,6 +94,7 @@ function valgahalla_synch_node_export_find_orphaned_fc_items() {
   $efq = new EntityFieldQuery();
   $efq->entityCondition('entity_type', 'field_collection_item');
   $efq->propertyCondition('field_name', 'field_volunteers_pr_pol_st_party');
+  $efq->propertyCondition('archived', 0);
   $efq->addTag('vppsp_host_null');
   $result = $efq->execute();
 
@@ -108,6 +110,7 @@ function valgahalla_synch_node_export_find_orphaned_fc_items() {
   $efq = new EntityFieldQuery();
   $efq->entityCondition('entity_type', 'field_collection_item');
   $efq->propertyCondition('field_name', 'field_volunteers_pr_pol_st_party');
+  $efq->propertyCondition('archived', 0);
   $efq->addTag('vppsp_field_ppsp_polling_station_empty');
   $result = $efq->execute();
 
@@ -122,6 +125,7 @@ function valgahalla_synch_node_export_find_orphaned_fc_items() {
   $efq = new EntityFieldQuery();
   $efq->entityCondition('entity_type', 'field_collection_item');
   $efq->propertyCondition('field_name', 'field_volunteers_pr_pol_st_party');
+  $efq->propertyCondition('archived', 0);
   $efq->addTag('vppsp_field_ppsp_party_empty');
   $result = $efq->execute();
 

--- a/public_html/profiles/valhalla/modules/valghalla/modules/valghalla_synch_node_export/valghalla_synch_node_export.module
+++ b/public_html/profiles/valhalla/modules/valghalla/modules/valghalla_synch_node_export/valghalla_synch_node_export.module
@@ -285,37 +285,111 @@ function valghalla_synch_node_export_delete_orphaned_fcs_init() {
 /**
  * Implements hook_query_TAG_alter().
  *
- * Valgahalla_synch_node_export_find_orphaned_fc_items -
- *   Valghalla Electioninfo node empty tag.
+ * Field_electioninfo - empty host node.
  */
-function valghalla_synch_node_export_query_veine_alter(QueryAlterableInterface $query) {
-  $vlt_query = new EntityFieldQuery();
-  $vlt_query->entityCondition('entity_type', 'node')
-    ->entityCondition('bundle', 'volunteers');
-  $result = $vlt_query->execute();
-  if (isset($result['node'])) {
-    $all_volunteers_ids = array_keys($result['node']);
-  }
+function valghalla_synch_node_export_query_ei_host_null_alter(QueryAlterableInterface $query) {
+  $query_exists = db_select('node', 'n');
+  $query_exists->addExpression('NULL');
+  $query_exists->where('n.nid=f.entity_id');
 
-  $query->join('field_data_field_electioninfo', 'fei', 'fei.field_electioninfo_value = field_collection_item.item_id');
-  $query->condition('fei.entity_id', $all_volunteers_ids, 'NOT IN');
+  $query->join('field_data_field_electioninfo', 'f', 'f.field_electioninfo_value = field_collection_item.item_id');
+  $query->notExists($query_exists);
 }
 
 /**
  * Implements hook_query_TAG_alter().
  *
- * Valgahalla_synch_node_export_find_orphaned_fc_items -
- *   Valghalla Volunteers_pr_pol_st_party node empty tag.
+ * Field_electioninfo - empty field_election node.
  */
-function valghalla_synch_node_export_query_vvppspne_alter(QueryAlterableInterface $query) {
-  $vlt_query = new EntityFieldQuery();
-  $vlt_query->entityCondition('entity_type', 'node')
-    ->entityCondition('bundle', 'election');
-  $result = $vlt_query->execute();
-  if (isset($result['node'])) {
-    $all_election_ids = array_keys($result['node']);
-  }
+function valghalla_synch_node_export_query_ei_field_election_empty_alter(QueryAlterableInterface $query) {
+  $query_exists = db_select('node', 'n');
+  $query_exists->addExpression('NULL');
+  $query_exists->where('n.nid=f.field_election_target_id');
 
-  $query->join('field_data_field_volunteers_pr_pol_st_party', 'fvppsp', 'fvppsp.field_volunteers_pr_pol_st_party_value = field_collection_item.item_id');
-  $query->condition('fvppsp.entity_id', $all_election_ids, 'NOT IN');
+  $query->leftJoin('field_data_field_election', 'f', 'f.entity_id = field_collection_item.item_id');
+  $query->notExists($query_exists);
+}
+
+/**
+ * Implements hook_query_TAG_alter().
+ *
+ * Field_electioninfo - empty field_post_role node.
+ */
+function valghalla_synch_node_export_query_ei_field_post_role_empty_alter(QueryAlterableInterface $query) {
+  $query_exists = db_select('node', 'n');
+  $query_exists->addExpression('NULL');
+  $query_exists->where('n.nid=f.field_post_role_target_id');
+
+  $query->leftJoin('field_data_field_post_role', 'f', 'f.entity_id = field_collection_item.item_id');
+  $query->notExists($query_exists);
+}
+
+/**
+ * Implements hook_query_TAG_alter().
+ *
+ * Field_electioninfo - empty field_vlnt_station node.
+ */
+function valghalla_synch_node_export_query_ei_field_vlnt_station_empty_alter(QueryAlterableInterface $query) {
+  $query_exists = db_select('node', 'n');
+  $query_exists->addExpression('NULL');
+  $query_exists->where('n.nid=f.field_vlnt_station_target_id');
+
+  $query->leftJoin('field_data_field_vlnt_station', 'f', 'f.entity_id = field_collection_item.item_id');
+  $query->notExists($query_exists);
+}
+
+/**
+ * Implements hook_query_TAG_alter().
+ *
+ * Field_electioninfo - empty field_post_party taxonomy term.
+ */
+function valghalla_synch_node_export_query_ei_field_post_party_empty_alter(QueryAlterableInterface $query) {
+  $query_exists = db_select('taxonomy_term_data', 't');
+  $query_exists->addExpression('NULL');
+  $query_exists->where('t.tid=f.field_post_party_target_id');
+
+  $query->leftJoin('field_data_field_post_party', 'f', 'f.entity_id = field_collection_item.item_id');
+  $query->notExists($query_exists);
+}
+
+/**
+ * Implements hook_query_TAG_alter().
+ *
+ * Field_electioninfo - empty host node.
+ */
+function valghalla_synch_node_export_query_vppsp_host_null_alter(QueryAlterableInterface $query) {
+  $query_exists = db_select('node', 'n');
+  $query_exists->addExpression('NULL');
+  $query_exists->where('n.nid=f.entity_id');
+
+  $query->join('field_data_field_volunteers_pr_pol_st_party', 'f', 'f.entity_id = field_collection_item.item_id');
+  $query->notExists($query_exists);
+}
+
+/**
+ * Implements hook_query_TAG_alter().
+ *
+ * Field_volunteers_pr_pol_st_party - empty field_ppsp_polling_station node.
+ */
+function valghalla_synch_node_export_query_vppsp_field_ppsp_polling_station_empty_alter(QueryAlterableInterface $query) {
+  $query_exists = db_select('node', 'n');
+  $query_exists->addExpression('NULL');
+  $query_exists->where('n.nid=f.field_ppsp_polling_station_nid');
+
+  $query->join('field_data_field_ppsp_polling_station', 'f', 'f.entity_id = field_collection_item.item_id');
+  $query->notExists($query_exists);
+}
+
+/**
+ * Implements hook_query_TAG_alter().
+ *
+ * Field_volunteers_pr_pol_st_party - empty field_ppsp_party node.
+ */
+function valghalla_synch_node_export_query_vppsp_field_ppsp_party_empty_alter(QueryAlterableInterface $query) {
+  $query_exists = db_select('taxonomy_term_data', 't');
+  $query_exists->addExpression('NULL');
+  $query_exists->where('t.tid=f.field_ppsp_party_tid');
+
+  $query->join('field_data_field_ppsp_party', 'f', 'f.entity_id = field_collection_item.item_id');
+  $query->notExists($query_exists);
 }

--- a/public_html/profiles/valhalla/modules/valghalla/modules/valghalla_synch_node_export/valghalla_synch_node_export.module
+++ b/public_html/profiles/valhalla/modules/valghalla/modules/valghalla_synch_node_export/valghalla_synch_node_export.module
@@ -355,7 +355,7 @@ function valghalla_synch_node_export_query_ei_field_post_party_empty_alter(Query
 /**
  * Implements hook_query_TAG_alter().
  *
- * Field_electioninfo - empty host node.
+ * Field_volunteers_pr_pol_st_party - empty host node.
  */
 function valghalla_synch_node_export_query_vppsp_host_null_alter(QueryAlterableInterface $query) {
   $query_exists = db_select('node', 'n');

--- a/public_html/profiles/valhalla/modules/valghalla/modules/valghalla_synch_node_export/valghalla_synch_node_export.module
+++ b/public_html/profiles/valhalla/modules/valghalla/modules/valghalla_synch_node_export/valghalla_synch_node_export.module
@@ -292,7 +292,7 @@ function valghalla_synch_node_export_query_ei_host_null_alter(QueryAlterableInte
   $query_exists->addExpression('NULL');
   $query_exists->where('n.nid=f.entity_id');
 
-  $query->join('field_data_field_electioninfo', 'f', 'f.field_electioninfo_value = field_collection_item.item_id');
+  $query->leftJoin('field_data_field_electioninfo', 'f', 'f.field_electioninfo_value = field_collection_item.item_id');
   $query->notExists($query_exists);
 }
 
@@ -362,7 +362,7 @@ function valghalla_synch_node_export_query_vppsp_host_null_alter(QueryAlterableI
   $query_exists->addExpression('NULL');
   $query_exists->where('n.nid=f.entity_id');
 
-  $query->join('field_data_field_volunteers_pr_pol_st_party', 'f', 'f.entity_id = field_collection_item.item_id');
+  $query->leftJoin('field_data_field_volunteers_pr_pol_st_party', 'f', 'f.field_volunteers_pr_pol_st_party_value = field_collection_item.item_id');
   $query->notExists($query_exists);
 }
 
@@ -376,7 +376,7 @@ function valghalla_synch_node_export_query_vppsp_field_ppsp_polling_station_empt
   $query_exists->addExpression('NULL');
   $query_exists->where('n.nid=f.field_ppsp_polling_station_nid');
 
-  $query->join('field_data_field_ppsp_polling_station', 'f', 'f.entity_id = field_collection_item.item_id');
+  $query->leftJoin('field_data_field_ppsp_polling_station', 'f', 'f.entity_id = field_collection_item.item_id');
   $query->notExists($query_exists);
 }
 
@@ -390,6 +390,6 @@ function valghalla_synch_node_export_query_vppsp_field_ppsp_party_empty_alter(Qu
   $query_exists->addExpression('NULL');
   $query_exists->where('t.tid=f.field_ppsp_party_tid');
 
-  $query->join('field_data_field_ppsp_party', 'f', 'f.entity_id = field_collection_item.item_id');
+  $query->leftJoin('field_data_field_ppsp_party', 'f', 'f.entity_id = field_collection_item.item_id');
   $query->notExists($query_exists);
 }

--- a/public_html/profiles/valhalla/modules/valghalla/modules/valghalla_synch_node_export/valghalla_synch_node_export.module
+++ b/public_html/profiles/valhalla/modules/valghalla/modules/valghalla_synch_node_export/valghalla_synch_node_export.module
@@ -281,3 +281,41 @@ function valghalla_synch_node_export_delete_orphaned_fcs_init() {
     batch_process(current_path());
   }
 }
+
+/**
+ * Implements hook_query_TAG_alter().
+ *
+ * Valgahalla_synch_node_export_find_orphaned_fc_items -
+ *   Valghalla Electioninfo node empty tag.
+ */
+function valghalla_synch_node_export_query_veine_alter(QueryAlterableInterface $query) {
+  $vlt_query = new EntityFieldQuery();
+  $vlt_query->entityCondition('entity_type', 'node')
+    ->entityCondition('bundle', 'volunteers');
+  $result = $vlt_query->execute();
+  if (isset($result['node'])) {
+    $all_volunteers_ids = array_keys($result['node']);
+  }
+
+  $query->join('field_data_field_electioninfo', 'fei', 'fei.field_electioninfo_value = field_collection_item.item_id');
+  $query->condition('fei.entity_id', $all_volunteers_ids, 'NOT IN');
+}
+
+/**
+ * Implements hook_query_TAG_alter().
+ *
+ * Valgahalla_synch_node_export_find_orphaned_fc_items -
+ *   Valghalla Volunteers_pr_pol_st_party node empty tag.
+ */
+function valghalla_synch_node_export_query_vvppspne_alter(QueryAlterableInterface $query) {
+  $vlt_query = new EntityFieldQuery();
+  $vlt_query->entityCondition('entity_type', 'node')
+    ->entityCondition('bundle', 'election');
+  $result = $vlt_query->execute();
+  if (isset($result['node'])) {
+    $all_election_ids = array_keys($result['node']);
+  }
+
+  $query->join('field_data_field_volunteers_pr_pol_st_party', 'fvppsp', 'fvppsp.field_volunteers_pr_pol_st_party_value = field_collection_item.item_id');
+  $query->condition('fvppsp.entity_id', $all_election_ids, 'NOT IN');
+}


### PR DESCRIPTION
Functionality check steps.
- [ ] Load dump (int and ext) of production instance. Better use any one with more that 100 volunteers (Frederikshavn, Gladsaxe)
- [ ] Get election numbers `drush ev "print_r(valghalla_synch_node_export_election_counts());"`
- [ ] Run "Delete orphaned field collections"  on internal
- [ ] Run "Delete orphaned field collections"  on external
- [ ] Run `drush valg-is`
- [ ] Get election numbers after `drush ev "print_r(valghalla_synch_node_export_election_counts());"`
- [ ] Compare and analyze difference