### PR TITLE
HOTFIX/POI-950-62706 Now validatings and notifying all seats

### DIFF
--- a/public_html/profiles/valhalla/modules/valghalla/modules/valghalla_internal_server/includes/valghalla_internal_server.batch.inc
+++ b/public_html/profiles/valhalla/modules/valghalla/modules/valghalla_internal_server/includes/valghalla_internal_server.batch.inc
@@ -109,50 +109,57 @@ function valghalla_internal_server_batch_clone_op($uuid, $operation_details, &$c
         ValghallaLogger::warning($logMessage);
       }
       else {
-        // Handle validation.
-        $validationStatus = valghalla_internal_server_validate_volunteer($node);
+        // Get all new and updated seats.
+        $seats = valghalla_internal_server_get_updated_seats($node, $existingNode);
 
-        if ($validationStatus['valid']) {
-          ValghallaLogger::info(sprintf('Node "%s" imported into %s', $node->title, url('node/' . $nid)));
-          $context['results'][] = array(
-            'message' => t('Node "@title" imported into <a href="@link">@title</a>.', array(
-              '@title' => $node->title,
-              '@link' => url('node/' . $nid),
-            )),
-            'type' => 'status',
-          );
+        // Count seats validation.
+        $seatValidationSuccessful = 0;
+        $seatValidationFailed = 0;
 
-          // Notify volunteer.
-          valghalla_internal_server_notify_volunteer_last_seat($node, $existingNode);
+        foreach ($seats as $seat) {
+          $seatValidationStatus = valghalla_internal_server_validate_volunteer_seat($node, $seat);
 
-          // Delete the item from queue.
-          valghalla_synch_queue_remove_item($node->uuid);
+          if ($seatValidationStatus['valid']) {
+            // Notify volunteer.
+            valghalla_volunteers_notify_volunteer($seat);
+
+            $seatValidationSuccessful++;
+          }
+          else {
+            ValghallaLogger::warning(sprintf('Node "%s" failed validation, messages %s', $node->title, implode('; ', $seatValidationStatus['errors'])));
+
+            /** @var EntityInterface $notification */
+            $valghalla_volunteer_validation_record = entity_get_controller('valghalla_volunteer_validation_record')->create(array(
+              'type' => 'external_server_sync',
+              'vol_id' => $node->nid,
+              'election_id' => $seatValidationStatus['election_nid'],
+              'message' => implode("\n", $seatValidationStatus['errors']),
+            ));
+            $valghalla_volunteer_validation_record->save();
+
+            valghalla_internal_server_mark_invalid($node, $seatValidationStatus['errors']);
+
+            // Freeing the seat.
+            valghalla_internal_server_volunteer_free_seat($seat);
+
+            $seatValidationFailed++;
+          }
         }
-        else {
-          ValghallaLogger::warning(sprintf('Node "%s" failed validation, messages %s', $node->title, implode('; ', $validationStatus['errors'])));
-          /** @var EntityInterface $notification */
-          $valghalla_volunteer_validation_record = entity_get_controller('valghalla_volunteer_validation_record')->create(array(
-            'type' => 'external_server_sync',
-            'vol_id' => $node->nid,
-            'election_id' => $validationStatus['election_nid'],
-            'message' => implode("\n", $validationStatus['errors']),
-          ));
-          $valghalla_volunteer_validation_record->save();
 
-          valghalla_internal_server_mark_invalid($node, $validationStatus['errors']);
+        ValghallaLogger::info(sprintf('Node "%s" imported into %s. %d/%d seats were successfully validated. %d seats failed validation', $node->title, url('node/' . $nid), $seatValidationSuccessful, count($seats), $seatValidationFailed));
+        $context['results'][] = array(
+          'message' => t('Node "@title" imported into <a href="@link">@title</a>. @valid/@total seats were successfully validated. @failed seats failed validation', array(
+            '@title' => $node->title,
+            '@link' => url('node/' . $nid),
+            '@valid' => $seatValidationSuccessful,
+            '@total' => count($seats),
+            '@failed' => $seatValidationFailed,
+          )),
+          'type' => 'status',
+        );
 
-          $context['results'][] = array(
-            'message' => t('Node "@title" imported into <a href="@link">@title</a>. But failed validation, seat will be freed. Messages: @messages', array(
-              '@title' => $node->title,
-              '@link' => url('node/' . $nid),
-              '@messages' => implode('; ', $validationStatus['errors']),
-            )),
-            'type' => 'status',
-          );
-
-          // Freeing the seat and pushing node.
-          valghalla_internal_server_free_last_selected_seat($node);
-
+        // If we have any failed seats, push the node to free the seats on external server.
+        if ($seatValidationFailed) {
           // Exporting with serialize formatter, and pushing the node.
           $export = node_export(intval($node->nid), 'serialize', 't', TRUE);
           $data = $export['output'];
@@ -164,20 +171,18 @@ function valghalla_internal_server_batch_clone_op($uuid, $operation_details, &$c
               $result = implode(' ', $result);
             }
 
-            ValghallaLogger::error(sprintf('Could not free seat for node "%s", error: %s', $node->title, $result));
-            $context['results'][] = array(
-              'message' => t('Could not free seat for "@title" push failed, message: @message', array(
-                '@title' => $node->title,
-                '@message' => $result,
-              )),
-              'type' => 'warning',
-            );
+            ValghallaLogger::error(sprintf('Could not free seat(s) for node "%s", error: %s', $node->title, $result));
           }
           else {
-            ValghallaLogger::info(sprintf('Seat for node "%s" has been freed %s', $node->title, implode('; ', $validationStatus['errors'])));
+            ValghallaLogger::info(sprintf('Seat(s) for node "%s" has been freed', $node->title));
+
             // Delete the item from queue.
             valghalla_synch_queue_remove_item($node->uuid);
           }
+        }
+        else {
+          // Else just delete the item from queue.
+          valghalla_synch_queue_remove_item($node->uuid);
         }
       }
     }

--- a/public_html/profiles/valhalla/modules/valghalla/modules/valghalla_internal_server/includes/valghalla_internal_server.batch.inc
+++ b/public_html/profiles/valhalla/modules/valghalla/modules/valghalla_internal_server/includes/valghalla_internal_server.batch.inc
@@ -158,7 +158,8 @@ function valghalla_internal_server_batch_clone_op($uuid, $operation_details, &$c
           'type' => 'status',
         );
 
-        // If we have any failed seats, push the node to free the seats on external server.
+        // If we have any failed seats, push the node to free the seats on
+        // external server.
         if ($seatValidationFailed) {
           // Exporting with serialize formatter, and pushing the node.
           $export = node_export(intval($node->nid), 'serialize', 't', TRUE);

--- a/public_html/profiles/valhalla/modules/valghalla/modules/valghalla_internal_server/includes/valghalla_internal_server.utils.inc
+++ b/public_html/profiles/valhalla/modules/valghalla/modules/valghalla_internal_server/includes/valghalla_internal_server.utils.inc
@@ -6,15 +6,87 @@
  */
 
 /**
- * Performs a validation on a single volunteer node.
+ * Compares two volunteer nodes.
+ *
+ * Calculates new and updated election info between first and the second node.
+ *
+ * @param mixed $volunteer
+ *   First volunteer node.
+ * @param mixed $volunteer_revision
+ *   Second volunteer node.
+ *
+ * @return array
+ *   Array of election info field collections, mapped by uuid.
+ */
+function valghalla_internal_server_get_updated_seats($volunteer, $volunteer_revision) {
+  $volunteer_seats = array();
+  $volunteer_revision_seats = array();
+
+  $field_electioninfo = field_get_items('node', $volunteer, 'field_electioninfo');
+  if (!empty($field_electioninfo)) {
+    foreach ($field_electioninfo as $election_info) {
+      $item = entity_load_single('field_collection_item', $election_info['value']);
+      $volunteer_seats[$item->uuid] = $item;
+    }
+  }
+
+  if ($volunteer_revision) {
+    $revision_field_electioninfo = field_get_items('node', $volunteer_revision, 'field_electioninfo');
+    if (!empty($revision_field_electioninfo)) {
+      foreach ($revision_field_electioninfo as $revision_election_info) {
+        $revision_item = entity_load_single('field_collection_item', $revision_election_info['value']);
+
+        // If field collection with the same uuid is already present in the
+        // volunteer_revision, we check if RSVP field has been changed.
+        // If yes - field collection has been updated, if not - we consider it
+        // has not been changed.
+        if (array_key_exists($revision_item->uuid, $volunteer_seats)) {
+
+          $revision_field_rsvp = field_get_items('field_collection_item', $revision_item, 'field_rsvp');
+          if (!empty($revision_field_rsvp)) {
+            $revision_rsvp = $revision_field_rsvp[0]['value'];
+          }
+
+          $field_rsvp = field_get_items('field_collection_item', $volunteer_seats[$revision_item->uuid], 'field_rsvp');
+          if (!empty($field_rsvp)) {
+            $rsvp = $field_rsvp[0]['value'];
+          }
+
+          // RSVP field has been changed, don't add this seat to the list of
+          // existing seats.
+          if (strcmp($rsvp, $revision_rsvp) !== 0) {
+            continue;
+          }
+        }
+        $volunteer_revision_seats[$revision_item->uuid] = $revision_item;
+      }
+    }
+  }
+
+  if (!empty($volunteer_revision_seats)) {
+    // Return all entries from $volunteer_seats that are not present in
+    // $volunteer_revision_seats.
+    return array_diff_key($volunteer_seats, $volunteer_revision_seats);
+  }
+  else {
+    return $volunteer_seats;
+  }
+}
+
+/**
+ * Performs a validation of a single volunteer node.
+ *
+ * Also performs the seat validation.
  *
  * @param mixed $volunteer_node
  *   Volunteer node.
+ * @param mixed $seat
+ *   Seat to validate against.
  *
  * @return array
  *   Array with keys 'valid' - boolean, 'errors' - list of errors.
  */
-function valghalla_internal_server_validate_volunteer($volunteer_node) {
+function valghalla_internal_server_validate_volunteer_seat($volunteer_node, $seat) {
   $validationStatus = array(
     'valid' => TRUE,
     'errors' => array(),
@@ -40,31 +112,27 @@ function valghalla_internal_server_validate_volunteer($volunteer_node) {
   // Run volunteer create validator.
   $messages = valghalla_volunteer_validator_query_service('validate_cpr', $cpr);
 
-  // Run volunteer validator per last election.
-  $field_electioninfo = field_get_items('node', $volunteer_node, 'field_electioninfo');
-  if (!empty($field_electioninfo)) {
-    $lastElement = end($field_electioninfo);
-    $electionInfo = entity_load_single('field_collection_item', $lastElement['value']);
+  // Run volunteer seat validation.
+  $electionInfo = $seat;
 
-    // Getting election.
-    $field_election = field_get_items('field_collection_item', $electionInfo, 'field_election');
-    if (!empty($field_election)) {
-      $election_nid = $field_election[0]['target_id'];
-      $election = node_load($election_nid);
-    }
+  // Getting election.
+  $field_election = field_get_items('field_collection_item', $electionInfo, 'field_election');
+  if (!empty($field_election)) {
+    $election_nid = $field_election[0]['target_id'];
+    $election = node_load($election_nid);
+  }
 
-    // Getting party.
-    $field_post_party = field_get_items('field_collection_item', $electionInfo, 'field_post_party');
-    if (!empty($field_post_party)) {
-      $party_tid = $field_post_party[0]['target_id'];
-      $party = taxonomy_term_load($party_tid);
-    }
+  // Getting party.
+  $field_post_party = field_get_items('field_collection_item', $electionInfo, 'field_post_party');
+  if (!empty($field_post_party)) {
+    $party_tid = $field_post_party[0]['target_id'];
+    $party = taxonomy_term_load($party_tid);
+  }
 
-    // Getting election date.
-    $field_election_date = field_get_items('node', $election, 'field_date');
-    if (!empty($field_election_date)) {
-      $election_date = $field_election_date[0]['value'];
-    }
+  // Getting election date.
+  $field_election_date = field_get_items('node', $election, 'field_date');
+  if (!empty($field_election_date)) {
+    $election_date = $field_election_date[0]['value'];
   }
 
   if ($election && $party) {
@@ -135,21 +203,13 @@ function valghalla_internal_server_term_to_json($term) {
 }
 
 /**
- * Unsets the last selected seat from the volunteer.
+ * Unsets the seat selected seat from the volunteer.
  *
- * @param mixed $volunteer
- *   Volunteer node.
+ * @param mixed $seat
+ *   Seat to unset.
  */
-function valghalla_internal_server_free_last_selected_seat($volunteer) {
-  $field_electioninfo = field_get_items('node', $volunteer, 'field_electioninfo');
-
-  if (!empty($field_electioninfo)) {
-    $fc_field = end($field_electioninfo);
-    if ($fc_field['value']) {
-      $fc = entity_load_single('field_collection_item', $fc_field['value']);
-      $fc->delete();
-    }
-  }
+function valghalla_internal_server_volunteer_free_seat($seat) {
+  $seat->delete();
 }
 
 /**
@@ -209,45 +269,6 @@ function valghalla_internal_server_get_external_server_url() {
   }
 
   return $external_server_url;
-}
-
-/**
- * Notifies volunteer about the last created seat, with status 'confirmed'.
- *
- * @param mixed $node
- *   Volunteer node.
- * @param mixed $previousNode
- *   Volunteer node previous version.
- */
-function valghalla_internal_server_notify_volunteer_last_seat($node, $previousNode) {
-  $electionInfo = NULL;
-
-  $field_electioninfo = field_get_items('node', $node, 'field_electioninfo');
-  if (!empty($field_electioninfo)) {
-    $lastElement = end($field_electioninfo);
-    $electionInfo = entity_load_single('field_collection_item', $lastElement['value']);
-  }
-
-  if ($electionInfo) {
-    $forceType = NULL;
-
-    // No previous node, meaning that volunteer is using subscription form.
-    // In that case, the notification type is confirmed.
-    if (!$previousNode) {
-      $forceType = 'confirmed';
-    }
-    else {
-      // If the size of current electionInfo is bigger, it means a new election
-      // info has been added with positive reply.
-      // In this case, the notification type is confirmed.
-      $previousElectionInfo = field_get_items('node', $previousNode, 'field_electioninfo');
-      if (empty($previousElectionInfo) || count($field_electioninfo) != count($previousElectionInfo)) {
-        $forceType = 'confirmed';
-      }
-    }
-
-    valghalla_volunteers_notify_volunteer($electionInfo, $forceType);
-  }
 }
 
 /**

--- a/public_html/profiles/valhalla/modules/valghalla/modules/valghalla_volunteers/valghalla_volunteers.module
+++ b/public_html/profiles/valhalla/modules/valghalla/modules/valghalla_volunteers/valghalla_volunteers.module
@@ -1250,10 +1250,8 @@ function valghalla_volunteers_remove_volunteer_from_post($fcid){
  *
  * @param mixed $electionInfo
  *   Election info field collection.
- * @param string $forceType
- *   If we are forcing some notification type.
  */
-function valghalla_volunteers_notify_volunteer($electionInfo, $forceType = NULL) {
+function valghalla_volunteers_notify_volunteer($electionInfo) {
   $field_election = field_get_items('field_collection_item', $electionInfo, 'field_election');
   if (!empty($field_election)) {
     $election_nid = $field_election[0]['target_id'];
@@ -1266,30 +1264,23 @@ function valghalla_volunteers_notify_volunteer($electionInfo, $forceType = NULL)
   if ($election_nid && $role_nid) {
     $type = NULL;
 
-    // Force type is used.
-    if ($forceType) {
-      $type = $forceType;
+    $field_rsvp = field_get_items('field_collection_item', $electionInfo, 'field_rsvp');
+    if (!empty($field_rsvp)) {
+      $rsvp = $field_rsvp[0]['value'];
     }
-    // No forced type, extract the type from the RSVP reply.
-    else {
-      $field_rsvp = field_get_items('field_collection_item', $electionInfo, 'field_rsvp');
-      if (!empty($field_rsvp)) {
-        $rsvp = $field_rsvp[0]['value'];
-      }
 
-      switch ($rsvp) {
-        case 1:
-          $type = 'confirmed';
-          break;
+    switch ($rsvp) {
+      case 1:
+        $type = 'confirmed';
+        break;
 
-        case 2:
-          $type = 'rsvp_no';
-          break;
+      case 2:
+        $type = 'rsvp_no';
+        break;
 
-        case 3:
-          $type = 'rsvp_never';
-          break;
-      }
+      case 3:
+        $type = 'rsvp_never';
+        break;
     }
 
     valghalla_volunteers_notify($election_nid, $role_nid, $electionInfo, $type);


### PR DESCRIPTION
The problem was reported with ticket: POI-950-62706.

According to it, only last seat was validated and notified about.
This means that if volunteer has subscribed himself on external server to two different elections, and then a synch has run, the volunteer will only get the notification about last seat (also the validation would only be run against the last seat).

This fix makes sure that all new/updated seats are being validated against and notified about.

Test cases used during testing:
1. Adding volunteer to one election (external server) and getting notification about it after synch
CHECK

2. Replying RSVP YES (external server) getting notification after synch
CHECK

3. Adding volunteer to two election (external server) and getting notification about both after synch
CHECK

4. Answering YES to one election (external server) and adding volunteer to another election (external server) getting notification from each of them after synch
CHECK

5. Answering YES to two elections (external server) getting notification from each of them after synch
CHECK

6. Adding volunteer to two election (external server) where one is supposed the fail, getting notification for one only after synch, freeing the invalid seat
CHECK
